### PR TITLE
Pass on to GHC when given flags that conflict with -M.

### DIFF
--- a/ghc-make.cabal
+++ b/ghc-make.cabal
@@ -27,4 +27,5 @@ executable ghc-make
     ghc-options: -threaded
     build-depends:
         base == 4.*,
-        shake == 0.10.*
+        shake == 0.10.*,
+        process >= 1.0


### PR DESCRIPTION
Same for the critical --version and --numeric-version flags, which programs like cabal use to determine the GHC version.

ghc-make can now be used with cabal like `cabal build --with-ghc=ghc-make`.

---

(This is [exactly the same as with ghc-parmake](https://github.com/nh2/ghc-parmake/commit/1dc43dc9985bf03da6cbfcefe75240d59eb7afd9).)

---

My results:

I tried this on a library with 400 modules, with a no-op build:

Cabal with plain ghc:

```
time cabal-dev build lib:mylib
cabal-dev build lib:mylib  4.08s user 0.36s system 97% cpu 4.538 total
```

Cabal with ghc-make, first time:

```
time cabal-dev build --with-ghc=ghc-make ib:mylib
cabal-dev build --with-ghc=ghc-make lib:mylib  5.16s user 0.48s system 96% cpu 5.839 total
```

Cabal with ghc-make, following times:

```
time cabal-dev build --with-ghc=ghc-make lib:mylib
cabal-dev build --with-ghc=ghc-make lib:mylib  1.98s user 0.22s system 98% cpu 2.240 total
```

The effect is not as visible as when you use `ghc --make` without cabal, but factor 2 for no-op builds is still quite good. I wonder if I can change cabal so that its own overhead is a bit less - then even cabal builds could be sub-second.
